### PR TITLE
Changing link to description page.

### DIFF
--- a/src/bib_config.ts
+++ b/src/bib_config.ts
@@ -19,7 +19,7 @@ export const API_TIMEOUT = 30 * 1000
 // what the actual abs section is to be called
 export const POLICY_SECTION_HEADER = 'Bibliographic data'
 export const POLICY_PROJECT_SHORTNAME = 'Bibex'
-export const POLICY_DESCRIPTION_PAGE = 'https://labs.arxiv.org/projects/bibexplorer'
+export const POLICY_DESCRIPTION_PAGE = 'https://labs.arxiv.org'
 
 // whether or not to trap the api calls that are made for stats purposes
 export const POLICY_RECORD_API_STATS = true


### PR DESCRIPTION
The "What is Bibex?" link displayed on the abs pages currently points
to non-existent page.

ARXIVNG-2721